### PR TITLE
Add Google Benchmark suite with run-history recording

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,8 @@ jobs:
           _bench/benchmarks/probstructs_benchmark \
             --benchmark_out="${RESULT}" \
             --benchmark_out_format=json \
-            --benchmark_color=false
+            --benchmark_color=false \
+            --benchmark_repetitions=3
           echo "RESULT_FILE=${RESULT}" >> "$GITHUB_ENV"
 
       - name: Find baseline on master
@@ -96,7 +97,7 @@ jobs:
           uv run scripts/bench_check_regression.py \
             --baseline /tmp/baseline.json \
             --current  "${{ env.RESULT_FILE }}" \
-            --threshold 5
+            --threshold 10
 
       # Runs only on direct pushes to master (not on PRs).
       # Commits the new result file so it becomes the baseline for the next PR.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,9 @@ jobs:
 
       - name: Run benchmarks
         run: |
-          mkdir -p benchmark_results
+          mkdir -p benchmark_results/ci
           TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
-          RESULT="benchmark_results/${TIMESTAMP}.json"
+          RESULT="benchmark_results/ci/${TIMESTAMP}.json"
           _bench/benchmarks/probstructs_benchmark \
             --benchmark_out="${RESULT}" \
             --benchmark_out_format=json \
@@ -77,7 +77,7 @@ jobs:
         id: baseline
         run: |
           git fetch origin master
-          LATEST=$(git ls-tree -r origin/master --name-only -- benchmark_results/ \
+          LATEST=$(git ls-tree -r origin/master --name-only -- benchmark_results/ci/ \
                    | grep '\.json$' | sort | tail -1)
           if [ -n "$LATEST" ]; then
             git show "origin/master:${LATEST}" > /tmp/baseline.json
@@ -103,7 +103,7 @@ jobs:
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add benchmark_results/
+          git add benchmark_results/ci/
           if git diff --cached --quiet; then
             echo "Nothing to commit."
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,112 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  # ── Unit Tests ──────────────────────────────────────────────────────────────
+  #
+  # Builds and runs the full test suite on Linux, macOS, and Windows.
+  # A failure here blocks the PR.
+  test:
+    name: Tests / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure
+        run: cmake -S . -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -B _build
+
+      - name: Build
+        run: cmake --build _build
+
+      - name: Run tests
+        run: ctest --test-dir _build --output-on-failure
+
+  # ── Benchmark Regression Check ──────────────────────────────────────────────
+  #
+  # Builds and runs the benchmark suite on a fixed Ubuntu runner to keep
+  # hardware consistent.  On PRs it compares results against the latest JSON
+  # committed to master and fails if any benchmark is >5 % slower.  On pushes
+  # to master it commits the new result file so future PRs have a fresh baseline.
+  #
+  # NOTE: GitHub Actions runners are virtualised; measurements can vary by
+  # ±2–3 % between runs.  The 5 % threshold provides headroom for that noise.
+  # Widen --threshold if the check becomes flaky on your setup.
+  benchmark:
+    name: Benchmark Regression Check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # required to push result files on master
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history so we can read master's result files
+
+      - name: Configure benchmarks
+        run: |
+          cmake -S . \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_BENCHMARKS=ON \
+            -B _bench
+
+      - name: Build benchmarks
+        run: cmake --build _bench --target probstructs_benchmark
+
+      - name: Run benchmarks
+        run: |
+          mkdir -p benchmark_results
+          TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
+          RESULT="benchmark_results/${TIMESTAMP}.json"
+          _bench/benchmarks/probstructs_benchmark \
+            --benchmark_out="${RESULT}" \
+            --benchmark_out_format=json \
+            --benchmark_color=false
+          echo "RESULT_FILE=${RESULT}" >> "$GITHUB_ENV"
+
+      - name: Find baseline on master
+        id: baseline
+        run: |
+          git fetch origin master
+          LATEST=$(git ls-tree -r origin/master --name-only -- benchmark_results/ \
+                   | grep '\.json$' | sort | tail -1)
+          if [ -n "$LATEST" ]; then
+            git show "origin/master:${LATEST}" > /tmp/baseline.json
+            echo "exists=true"  >> "$GITHUB_OUTPUT"
+            echo "Baseline: ${LATEST}"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "No baseline found on master — skipping regression check."
+          fi
+
+      - name: Check for regressions
+        if: steps.baseline.outputs.exists == 'true'
+        run: |
+          python3 scripts/bench_check_regression.py \
+            --baseline /tmp/baseline.json \
+            --current  "${{ env.RESULT_FILE }}" \
+            --threshold 5
+
+      # Runs only on direct pushes to master (not on PRs).
+      # Commits the new result file so it becomes the baseline for the next PR.
+      - name: Commit benchmark results to master
+        if: github.ref == 'refs/heads/master'
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add benchmark_results/
+          if git diff --cached --quiet; then
+            echo "Nothing to commit."
+          else
+            git pull --rebase origin master
+            git commit -m "ci: record benchmark results [skip ci]"
+            git push
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
         with:
           fetch-depth: 0   # full history so we can read master's result files
 
+      - uses: astral-sh/setup-uv@v5
+
       - name: Configure benchmarks
         run: |
           cmake -S . \
@@ -91,7 +93,7 @@ jobs:
       - name: Check for regressions
         if: steps.baseline.outputs.exists == 'true'
         run: |
-          python3 scripts/bench_check_regression.py \
+          uv run scripts/bench_check_regression.py \
             --baseline /tmp/baseline.json \
             --current  "${{ env.RESULT_FILE }}" \
             --threshold 5

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ _debug/*
 _release/*
 _bench/*
 
+# Local benchmark results (CI results in benchmark_results/ci/ are committed)
+benchmark_results/local/
+
 # Idea files:
 cmake-build-debug/
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@
 # Build folders
 _debug/*
 _release/*
+_bench/*
 
 # Idea files:
 cmake-build-debug/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,19 +39,21 @@ On Windows, ctest needs `-C Debug` because the VS generator is multi-config.
 
 ## Benchmarks
 
-Google Benchmark suite, opt-in (`BUILD_BENCHMARKS=OFF` by default):
+Google Benchmark suite, opt-in (`BUILD_BENCHMARKS=OFF` by default).
+Requires **uv** for the comparison and regression scripts (fetches `numpy`/`scipy` automatically).
 
 ```bash
 make bench-build     # configure + compile benchmarks
 make bench-run       # run and save results to benchmark_results/local/<timestamp>.json
-make bench-compare   # compare the two most-recent local results
+make bench-compare   # compare the two most-recent local results (uses uv)
 ```
 
 Result directories:
-- `benchmark_results/local/` — gitignored; local developer runs
-- `benchmark_results/ci/` — committed; CI baseline used for regression checks
+- `benchmark_results/local/` — gitignored; local developer runs only
+- `benchmark_results/ci/` — committed to master; CI regression baseline
 
-`bench_compare.sh` and `bench_check_regression.py` are invoked via **uv** — dependencies (`numpy`, `scipy`) are fetched automatically on first use.
+`bench_compare.sh` calls Google Benchmark's `compare.py` via `uv run --with numpy --with scipy`.
+`bench_check_regression.py` has PEP 723 metadata and is invoked via `uv run`.
 
 ## CI
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# ProbStructs — Claude Code guidance
+
+## Project overview
+
+C++17 header-only library of probabilistic data structures:
+- `CountMinSketch` — frequency table of events in a stream
+- `ExponentialHistorgram` — frequency of a specific event in the last N elements
+- `ExponentialCountMinSketch` — frequency table of events in the last N elements
+
+Source lives in `probstructs/probstructs.h`. Tests are in `tests/`. Benchmarks are in `benchmarks/`.
+
+## Git workflow
+
+**Always open a PR — never push directly to `master`.**
+
+## Build
+
+```bash
+make debug-build     # configure + compile (Debug)
+make debug-test      # run unit tests (Debug)
+make release-build   # configure + compile (Release)
+```
+
+CMake is auto-detected from PATH and common Homebrew locations (`/opt/homebrew/bin`, `/usr/local/bin`).
+
+## Testing
+
+Unit tests use **Google Benchmark** (fetched via FetchContent at configure time):
+
+```bash
+make debug-test      # shortcut for the above
+# or directly:
+cmake -S . -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -B _build
+cmake --build _build
+ctest --test-dir _build --output-on-failure
+```
+
+On Windows, ctest needs `-C Debug` because the VS generator is multi-config.
+
+## Benchmarks
+
+Google Benchmark suite, opt-in (`BUILD_BENCHMARKS=OFF` by default):
+
+```bash
+make bench-build     # configure + compile benchmarks
+make bench-run       # run and save results to benchmark_results/local/<timestamp>.json
+make bench-compare   # compare the two most-recent local results
+```
+
+Result directories:
+- `benchmark_results/local/` — gitignored; local developer runs
+- `benchmark_results/ci/` — committed; CI baseline used for regression checks
+
+`bench_compare.sh` and `bench_check_regression.py` are invoked via **uv** — dependencies (`numpy`, `scipy`) are fetched automatically on first use.
+
+## CI
+
+Two workflows in `.github/workflows/`:
+- `ci.yml` — runs unit tests (Linux/macOS/Windows) and a benchmark regression check (Ubuntu only, fails if any benchmark is >5% slower than the committed baseline in `benchmark_results/ci/`). On pushes to `master` it commits the new benchmark result as the next baseline.
+- `build.yml` — legacy build/artifact workflow using `nicledomaS/cmake_build_action`; tests are disabled there because `ci.yml` covers all platforms.
+
+## Code conventions
+
+- C++17; use `uint32_t` (not `uint` — MSVC doesn't define `uint`)
+- Dependencies fetched via CMake FetchContent (fmtlib, googletest, googlebenchmark)
+- No external runtime dependencies

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Result directories:
 ## CI
 
 Two workflows in `.github/workflows/`:
-- `ci.yml` — runs unit tests (Linux/macOS/Windows) and a benchmark regression check (Ubuntu only, fails if any benchmark is >5% slower than the committed baseline in `benchmark_results/ci/`). On pushes to `master` it commits the new benchmark result as the next baseline.
+- `ci.yml` — runs unit tests (Linux/macOS/Windows) and a benchmark regression check (Ubuntu only, fails if any benchmark is >10% slower than the committed baseline in `benchmark_results/ci/`). Benchmarks run with `--benchmark_repetitions=3`; the regression check uses the mean aggregate. On pushes to `master` it commits the new benchmark result as the next baseline.
 - `build.yml` — legacy build/artifact workflow using `nicledomaS/cmake_build_action`; tests are disabled there because `ci.yml` covers all platforms.
 
 ## Code conventions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,8 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     # main CMakeLists.
     include(CTest)
 
+    option(BUILD_BENCHMARKS "Build benchmarks" OFF)
+
     # Docs only available if this is the main app
     find_package(Doxygen)
     if(Doxygen_FOUND)
@@ -83,4 +85,8 @@ endif()
 # Emergency override MODERN_CMAKE_BUILD_TESTING provided as well
 if((CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME OR MODERN_CMAKE_BUILD_TESTING) AND BUILD_TESTING)
     add_subdirectory(tests)
+endif()
+
+if((CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME OR MODERN_CMAKE_BUILD_BENCHMARKS) AND BUILD_BENCHMARKS)
+    add_subdirectory(benchmarks)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ endif()
 FetchContent_Declare(
         fmtlib
         GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-        GIT_TAG        5.3.0
+        GIT_TAG        10.2.1
 )
 FetchContent_MakeAvailable(fmtlib)
 # Adds fmt::fmt

--- a/Makefile
+++ b/Makefile
@@ -32,4 +32,19 @@ release-test: release-build
 
 
 clean:
-	rm -rf _debug _release
+	rm -rf _debug _release _bench
+
+
+_bench: bench-configure
+
+bench-configure:
+	cmake -S . -DCMAKE_BUILD_TYPE=Release -DBUILD_BENCHMARKS=ON -B _bench
+
+bench-build: _bench
+	cmake --build _bench --target probstructs_benchmark
+
+bench-run: bench-build
+	./scripts/bench_run.sh _bench/benchmarks/probstructs_benchmark
+
+bench-compare:
+	./scripts/bench_compare.sh

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,14 @@
-# You need latest cmake to make it work
-# https://apt.kitware.com/
+# Locate cmake — checks PATH first, then common Homebrew locations.
+CMAKE := $(or \
+	$(shell which cmake 2>/dev/null), \
+	$(wildcard /opt/homebrew/bin/cmake), \
+	$(wildcard /usr/local/bin/cmake))
+
+# Fail early with a helpful message if cmake is nowhere to be found.
+ifeq ($(CMAKE),)
+  $(error cmake not found. Install it with: brew install cmake  (macOS) \
+  or see https://apt.kitware.com/ (Linux))
+endif
 
 # sudo aptitude install doxygen graphviz
 # pip3 install breathe sphinx_rtd_theme
@@ -7,10 +16,10 @@
 _debug: debug-configure
 
 debug-configure:
-	cmake -S . -DCMAKE_BUILD_TYPE=Debug -B _debug
+	$(CMAKE) -S . -DCMAKE_BUILD_TYPE=Debug -B _debug
 
 debug-build: _debug
-	cmake --build _debug
+	$(CMAKE) --build _debug
 
 debug-test: debug-build
 	_debug/tests/probstructs_test
@@ -22,10 +31,10 @@ debug-valgrind: debug-build
 _release: release-configure
 
 release-configure:
-	cmake -S . -DCMAKE_BUILD_TYPE=Release -B _release
+	$(CMAKE) -S . -DCMAKE_BUILD_TYPE=Release -B _release
 
 release-build: _release
-	cmake --build _release
+	$(CMAKE) --build _release
 
 release-test: release-build
 	_release/tests/probstructs_test
@@ -38,10 +47,10 @@ clean:
 _bench: bench-configure
 
 bench-configure:
-	cmake -S . -DCMAKE_BUILD_TYPE=Release -DBUILD_BENCHMARKS=ON -B _bench
+	$(CMAKE) -S . -DCMAKE_BUILD_TYPE=Release -DBUILD_BENCHMARKS=ON -B _bench
 
 bench-build: _bench
-	cmake --build _bench --target probstructs_benchmark
+	$(CMAKE) --build _bench --target probstructs_benchmark
 
 bench-run: bench-build
 	./scripts/bench_run.sh _bench/benchmarks/probstructs_benchmark

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Probabilistic Structures
 
 `ProbStructs` as easy to use C++ library with probabilistic structures.
 
-|build-status| |docs| |github-stars-flat|
+|ci-status| |docs| |github-stars-flat|
 
 Documentation
 -------------
@@ -32,7 +32,7 @@ Example
 
     ExponentialCountMinSketch<int> sketch(100, 4, 8);
 
-    uint ts = 0;
+    uint32_t ts = 0;
 
     ts = 0;
     sketch.inc("aaa", ts, 1);
@@ -71,7 +71,6 @@ Example
     // 0
 
 
-
 Benchmarks
 ----------
 
@@ -81,17 +80,21 @@ install on macOS with ``brew install cmake``):
 .. code-block:: bash
 
     make bench-build    # fetches Google Benchmark, compiles
-    make bench-run      # runs and saves results to benchmark_results/<timestamp>.json
-    make bench-compare  # compares the two most-recent result files
+    make bench-run      # runs and saves results to benchmark_results/local/<timestamp>.json
+    make bench-compare  # compares the two most-recent local result files
+
+Results are stored in ``benchmark_results/local/`` (gitignored, per-machine)
+so local runs never pollute the repo. CI results are committed to
+``benchmark_results/ci/`` and used as the regression baseline for pull requests.
 
 See the `full benchmark documentation`_ for details on filtering, repeating
 runs, and comparing specific result files.
 
 .. _full benchmark documentation: https://probstructs.readthedocs.io/en/latest/benchmarks.html
 
-.. |build-status| image:: https://travis-ci.org/martin-majlis/probstructs.svg?branch=master
-    :alt: build status
-    :target: https://travis-ci.org/martin-majlis/probstructs
+.. |ci-status| image:: https://github.com/martin-majlis/probstructs/actions/workflows/ci.yml/badge.svg
+    :alt: CI status
+    :target: https://github.com/martin-majlis/probstructs/actions/workflows/ci.yml
 
 .. |docs| image:: https://readthedocs.org/projects/probstructs/badge/?version=latest
     :target: http://probstructs.readthedocs.io/en/latest/?badge=latest

--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,8 @@ Example
 Benchmarks
 ----------
 
-Build and run the benchmark suite (requires CMake and a C++17 compiler):
+Build and run the benchmark suite (requires CMake 3.11+ and a C++17 compiler;
+install on macOS with ``brew install cmake``):
 
 .. code-block:: bash
 

--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,22 @@ Example
 
 
 
+Benchmarks
+----------
+
+Build and run the benchmark suite (requires CMake and a C++17 compiler):
+
+.. code-block:: bash
+
+    make bench-build    # fetches Google Benchmark, compiles
+    make bench-run      # runs and saves results to benchmark_results/<timestamp>.json
+    make bench-compare  # compares the two most-recent result files
+
+See the `full benchmark documentation`_ for details on filtering, repeating
+runs, and comparing specific result files.
+
+.. _full benchmark documentation: https://probstructs.readthedocs.io/en/latest/benchmarks.html
+
 .. |build-status| image:: https://travis-ci.org/martin-majlis/probstructs.svg?branch=master
     :alt: build status
     :target: https://travis-ci.org/martin-majlis/probstructs

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.11...3.17)
+
+include(FetchContent)
+if(${CMAKE_VERSION} VERSION_LESS 3.14)
+    include(cmake/add_FetchContent_MakeAvailable.cmake)
+endif()
+
+FetchContent_Declare(
+    googlebenchmark
+    GIT_REPOSITORY https://github.com/google/benchmark.git
+    GIT_TAG        v1.9.1
+)
+set(BENCHMARK_ENABLE_TESTING     OFF CACHE BOOL "" FORCE)
+set(BENCHMARK_ENABLE_INSTALL     OFF CACHE BOOL "" FORCE)
+set(BENCHMARK_ENABLE_GTEST_TESTS OFF CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googlebenchmark)
+
+set(CMAKE_CXX_STANDARD 17)
+
+add_executable(probstructs_benchmark probstructs_benchmark.cpp)
+target_link_libraries(probstructs_benchmark
+    PRIVATE benchmark::benchmark benchmark::benchmark_main probstructs)

--- a/benchmarks/probstructs_benchmark.cpp
+++ b/benchmarks/probstructs_benchmark.cpp
@@ -1,6 +1,7 @@
 #include <benchmark/benchmark.h>
 #include <algorithm>
 #include <cmath>
+#include <memory>
 #include <random>
 #include <string>
 #include <vector>

--- a/benchmarks/probstructs_benchmark.cpp
+++ b/benchmarks/probstructs_benchmark.cpp
@@ -1,0 +1,164 @@
+#include <benchmark/benchmark.h>
+#include <string>
+#include <vector>
+#include "../probstructs/probstructs.h"
+
+using namespace probstructs;
+
+// Pre-generated key pool — avoids measuring string construction inside the timed loop.
+static const int KEY_POOL_SIZE = 1024;
+static std::vector<std::string> g_keys;
+
+static void InitKeys() {
+    if (!g_keys.empty()) return;
+    g_keys.reserve(KEY_POOL_SIZE);
+    for (int i = 0; i < KEY_POOL_SIZE; ++i) {
+        g_keys.push_back("key_" + std::to_string(i));
+    }
+}
+
+// ---------- CountMinSketch ---------------------------------------------------
+
+class CountMinSketchFixture : public benchmark::Fixture {
+public:
+    std::unique_ptr<CountMinSketch<int>> sketch;
+
+    void SetUp(const benchmark::State& state) override {
+        InitKeys();
+        uint32_t width = static_cast<uint32_t>(state.range(0));
+        uint8_t  depth = static_cast<uint8_t>(state.range(1));
+        sketch = std::make_unique<CountMinSketch<int>>(width, depth);
+        for (int i = 0; i < KEY_POOL_SIZE; ++i) {
+            sketch->inc(g_keys[i], 1);
+        }
+    }
+
+    void TearDown(const benchmark::State&) override {
+        sketch.reset();
+    }
+};
+
+BENCHMARK_DEFINE_F(CountMinSketchFixture, Inc)(benchmark::State& state) {
+    int64_t i = 0;
+    for (auto _ : state) {
+        sketch->inc(g_keys[i % KEY_POOL_SIZE], 1);
+        ++i;
+    }
+    state.SetItemsProcessed(state.iterations());
+}
+
+BENCHMARK_DEFINE_F(CountMinSketchFixture, Get)(benchmark::State& state) {
+    int64_t i = 0;
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(sketch->get(g_keys[i % KEY_POOL_SIZE]));
+        ++i;
+    }
+    state.SetItemsProcessed(state.iterations());
+}
+
+// width, depth
+BENCHMARK_REGISTER_F(CountMinSketchFixture, Inc)->Args({100,   3});
+BENCHMARK_REGISTER_F(CountMinSketchFixture, Inc)->Args({1000,  5});
+BENCHMARK_REGISTER_F(CountMinSketchFixture, Inc)->Args({10000, 7});
+BENCHMARK_REGISTER_F(CountMinSketchFixture, Get)->Args({100,   3});
+BENCHMARK_REGISTER_F(CountMinSketchFixture, Get)->Args({1000,  5});
+BENCHMARK_REGISTER_F(CountMinSketchFixture, Get)->Args({10000, 7});
+
+// ---------- ExponentialHistorgram --------------------------------------------
+
+class ExponentialHistorgramFixture : public benchmark::Fixture {
+public:
+    std::unique_ptr<ExponentialHistorgram<int>> eh;
+
+    void SetUp(const benchmark::State& state) override {
+        uint32_t window = static_cast<uint32_t>(state.range(0));
+        eh = std::make_unique<ExponentialHistorgram<int>>(window);
+        for (uint32_t t = 0; t < 64; ++t) {
+            eh->inc(t, 1);
+        }
+    }
+
+    void TearDown(const benchmark::State&) override {
+        eh.reset();
+    }
+};
+
+BENCHMARK_DEFINE_F(ExponentialHistorgramFixture, Inc)(benchmark::State& state) {
+    uint32_t tick = 1000;
+    for (auto _ : state) {
+        eh->inc(tick, 1);
+        ++tick;
+    }
+    state.SetItemsProcessed(state.iterations());
+}
+
+BENCHMARK_DEFINE_F(ExponentialHistorgramFixture, Get)(benchmark::State& state) {
+    uint32_t window = static_cast<uint32_t>(state.range(0));
+    uint32_t tick   = 1000;
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(eh->get(window / 2, tick));
+        ++tick;
+    }
+    state.SetItemsProcessed(state.iterations());
+}
+
+// window
+BENCHMARK_REGISTER_F(ExponentialHistorgramFixture, Inc)->Arg(64);
+BENCHMARK_REGISTER_F(ExponentialHistorgramFixture, Inc)->Arg(1024);
+BENCHMARK_REGISTER_F(ExponentialHistorgramFixture, Inc)->Arg(16384);
+BENCHMARK_REGISTER_F(ExponentialHistorgramFixture, Get)->Arg(64);
+BENCHMARK_REGISTER_F(ExponentialHistorgramFixture, Get)->Arg(1024);
+BENCHMARK_REGISTER_F(ExponentialHistorgramFixture, Get)->Arg(16384);
+
+// ---------- ExponentialCountMinSketch ----------------------------------------
+
+class ECMSketchFixture : public benchmark::Fixture {
+public:
+    std::unique_ptr<ExponentialCountMinSketch<int>> sketch;
+    uint32_t window_;
+
+    void SetUp(const benchmark::State& state) override {
+        InitKeys();
+        uint32_t width = static_cast<uint32_t>(state.range(0));
+        uint8_t  depth = static_cast<uint8_t>(state.range(1));
+        window_        = static_cast<uint32_t>(state.range(2));
+        sketch = std::make_unique<ExponentialCountMinSketch<int>>(width, depth, window_);
+        for (int i = 0; i < KEY_POOL_SIZE; ++i) {
+            sketch->inc(g_keys[i], static_cast<uint32_t>(i), 1);
+        }
+    }
+
+    void TearDown(const benchmark::State&) override {
+        sketch.reset();
+    }
+};
+
+BENCHMARK_DEFINE_F(ECMSketchFixture, Inc)(benchmark::State& state) {
+    uint32_t tick = KEY_POOL_SIZE + 1;
+    int64_t  i    = 0;
+    for (auto _ : state) {
+        sketch->inc(g_keys[i % KEY_POOL_SIZE], tick, 1);
+        ++tick;
+        ++i;
+    }
+    state.SetItemsProcessed(state.iterations());
+}
+
+BENCHMARK_DEFINE_F(ECMSketchFixture, Get)(benchmark::State& state) {
+    uint32_t tick = KEY_POOL_SIZE + 1;
+    int64_t  i    = 0;
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(sketch->get(g_keys[i % KEY_POOL_SIZE], window_ / 2, tick));
+        ++tick;
+        ++i;
+    }
+    state.SetItemsProcessed(state.iterations());
+}
+
+// width, depth, window
+BENCHMARK_REGISTER_F(ECMSketchFixture, Inc)->Args({100,  3,   64});
+BENCHMARK_REGISTER_F(ECMSketchFixture, Inc)->Args({1000, 5, 1024});
+BENCHMARK_REGISTER_F(ECMSketchFixture, Inc)->Args({5000, 7, 4096});
+BENCHMARK_REGISTER_F(ECMSketchFixture, Get)->Args({100,  3,   64});
+BENCHMARK_REGISTER_F(ECMSketchFixture, Get)->Args({1000, 5, 1024});
+BENCHMARK_REGISTER_F(ECMSketchFixture, Get)->Args({5000, 7, 4096});

--- a/benchmarks/probstructs_benchmark.cpp
+++ b/benchmarks/probstructs_benchmark.cpp
@@ -1,164 +1,469 @@
 #include <benchmark/benchmark.h>
+#include <algorithm>
+#include <cmath>
+#include <random>
 #include <string>
 #include <vector>
+
 #include "../probstructs/probstructs.h"
 
 using namespace probstructs;
 
-// Pre-generated key pool — avoids measuring string construction inside the timed loop.
-static const int KEY_POOL_SIZE = 1024;
-static std::vector<std::string> g_keys;
+// ============================================================================
+// Shared test data — generated once at process start
+//
+// Three key-domain sizes mirror typical real workloads:
+//   POOL_SMALL  ( 1 K) — high collision rate, fits fully in L1/L2 cache
+//   POOL_MEDIUM (10 K) — moderate collisions, L2/L3 resident
+//   POOL_LARGE (100 K) — low collision rate, exercises cache pressure
+//
+// Two access distributions per pool:
+//   Uniform — every key equally likely
+//   Zipf(s=1) — top 1 % of keys receive ~50 % of traffic; realistic for
+//               web requests, event streams, user activity logs, etc.
+// ============================================================================
 
-static void InitKeys() {
-    if (!g_keys.empty()) return;
-    g_keys.reserve(KEY_POOL_SIZE);
-    for (int i = 0; i < KEY_POOL_SIZE; ++i) {
-        g_keys.push_back("key_" + std::to_string(i));
-    }
+static const int POOL_SMALL  =   1'000;
+static const int POOL_MEDIUM =  10'000;
+static const int POOL_LARGE  = 100'000;
+static const int SEQ_LEN     =  1'000'000;
+
+static std::vector<std::string> g_keys_small;
+static std::vector<std::string> g_keys_medium;
+static std::vector<std::string> g_keys_large;
+
+static std::vector<int> g_uniform_small,  g_uniform_medium,  g_uniform_large;
+static std::vector<int> g_zipf_small,     g_zipf_medium,     g_zipf_large;
+
+static void MakeKeys(std::vector<std::string>& v, int n) {
+    if (!v.empty()) return;
+    v.reserve(n);
+    for (int i = 0; i < n; ++i) v.push_back("key_" + std::to_string(i));
 }
 
-// ---------- CountMinSketch ---------------------------------------------------
+static std::vector<int> MakeUniformSeq(int pool, int len) {
+    std::mt19937 rng(42);
+    std::uniform_int_distribution<int> dist(0, pool - 1);
+    std::vector<int> seq(len);
+    for (auto& v : seq) v = dist(rng);
+    return seq;
+}
 
-class CountMinSketchFixture : public benchmark::Fixture {
+// Discrete Zipf sampler via precomputed CDF + binary search.
+static std::vector<int> MakeZipfSeq(int pool, int len) {
+    std::vector<double> cdf(pool);
+    double total = 0.0;
+    for (int k = 1; k <= pool; ++k) { total += 1.0 / k; cdf[k - 1] = total; }
+    for (auto& v : cdf) v /= total;
+
+    std::mt19937 rng(43);
+    std::uniform_real_distribution<double> dist(0.0, 1.0);
+    std::vector<int> seq(len);
+    for (auto& idx : seq) {
+        double r = dist(rng);
+        idx = static_cast<int>(std::lower_bound(cdf.begin(), cdf.end(), r) - cdf.begin());
+        if (idx >= pool) idx = pool - 1;
+    }
+    return seq;
+}
+
+static void InitGlobals() {
+    static bool done = false;
+    if (done) return;
+    done = true;
+    MakeKeys(g_keys_small,  POOL_SMALL);
+    MakeKeys(g_keys_medium, POOL_MEDIUM);
+    MakeKeys(g_keys_large,  POOL_LARGE);
+    g_uniform_small  = MakeUniformSeq(POOL_SMALL,  SEQ_LEN);
+    g_uniform_medium = MakeUniformSeq(POOL_MEDIUM, SEQ_LEN);
+    g_uniform_large  = MakeUniformSeq(POOL_LARGE,  SEQ_LEN);
+    g_zipf_small     = MakeZipfSeq(POOL_SMALL,  SEQ_LEN);
+    g_zipf_medium    = MakeZipfSeq(POOL_MEDIUM, SEQ_LEN);
+    g_zipf_large     = MakeZipfSeq(POOL_LARGE,  SEQ_LEN);
+}
+
+// pool_id 0/1/2 → small/medium/large
+static const std::vector<std::string>& KeyPool(int id) {
+    if (id == 0) return g_keys_small;
+    if (id == 1) return g_keys_medium;
+    return g_keys_large;
+}
+
+// dist_id 0=uniform, 1=zipf
+static const std::vector<int>& AccessSeq(int pool_id, int dist_id) {
+    if (dist_id == 1) {
+        if (pool_id == 0) return g_zipf_small;
+        if (pool_id == 1) return g_zipf_medium;
+        return g_zipf_large;
+    }
+    if (pool_id == 0) return g_uniform_small;
+    if (pool_id == 1) return g_uniform_medium;
+    return g_uniform_large;
+}
+
+// ============================================================================
+// CountMinSketch
+//
+// Parameters (via state.range):
+//   [0] width    — sketch width (controls accuracy vs memory)
+//   [1] depth    — number of hash functions (controls accuracy vs speed)
+//   [2] pool_id  — key domain size: 0=1K, 1=10K, 2=100K
+//   [3] dist_id  — access distribution: 0=uniform, 1=zipf
+//
+// With a uniform distribution, CMS latency is dominated purely by the hash +
+// memory-write pattern.  Zipf makes the hot bucket lines stay warm in cache,
+// which can show a modest improvement.  What matters more is whether the full
+// sketch (width * depth * sizeof(int) bytes) fits in L1 (≤ 32 KB), L2, or
+// spills to L3.
+// ============================================================================
+
+class CMSFixture : public benchmark::Fixture {
 public:
     std::unique_ptr<CountMinSketch<int>> sketch;
+    const std::vector<std::string>* keys = nullptr;
+    const std::vector<int>*         seq  = nullptr;
 
     void SetUp(const benchmark::State& state) override {
-        InitKeys();
-        uint32_t width = static_cast<uint32_t>(state.range(0));
-        uint8_t  depth = static_cast<uint8_t>(state.range(1));
-        sketch = std::make_unique<CountMinSketch<int>>(width, depth);
-        for (int i = 0; i < KEY_POOL_SIZE; ++i) {
-            sketch->inc(g_keys[i], 1);
-        }
+        InitGlobals();
+        keys   = &KeyPool(state.range(2));
+        seq    = &AccessSeq(state.range(2), state.range(3));
+        sketch = std::make_unique<CountMinSketch<int>>(
+                     static_cast<uint32_t>(state.range(0)),
+                     static_cast<uint8_t> (state.range(1)));
+        for (const auto& k : *keys) sketch->inc(k, 1);
     }
 
-    void TearDown(const benchmark::State&) override {
-        sketch.reset();
-    }
+    void TearDown(const benchmark::State&) override { sketch.reset(); }
 };
 
-BENCHMARK_DEFINE_F(CountMinSketchFixture, Inc)(benchmark::State& state) {
+BENCHMARK_DEFINE_F(CMSFixture, Inc)(benchmark::State& state) {
     int64_t i = 0;
     for (auto _ : state) {
-        sketch->inc(g_keys[i % KEY_POOL_SIZE], 1);
+        sketch->inc((*keys)[(*seq)[i % SEQ_LEN]], 1);
         ++i;
     }
     state.SetItemsProcessed(state.iterations());
 }
 
-BENCHMARK_DEFINE_F(CountMinSketchFixture, Get)(benchmark::State& state) {
+BENCHMARK_DEFINE_F(CMSFixture, Get)(benchmark::State& state) {
     int64_t i = 0;
     for (auto _ : state) {
-        benchmark::DoNotOptimize(sketch->get(g_keys[i % KEY_POOL_SIZE]));
+        benchmark::DoNotOptimize(sketch->get((*keys)[(*seq)[i % SEQ_LEN]]));
         ++i;
     }
     state.SetItemsProcessed(state.iterations());
 }
 
-// width, depth
-BENCHMARK_REGISTER_F(CountMinSketchFixture, Inc)->Args({100,   3});
-BENCHMARK_REGISTER_F(CountMinSketchFixture, Inc)->Args({1000,  5});
-BENCHMARK_REGISTER_F(CountMinSketchFixture, Inc)->Args({10000, 7});
-BENCHMARK_REGISTER_F(CountMinSketchFixture, Get)->Args({100,   3});
-BENCHMARK_REGISTER_F(CountMinSketchFixture, Get)->Args({1000,  5});
-BENCHMARK_REGISTER_F(CountMinSketchFixture, Get)->Args({10000, 7});
+// 80 % inc / 20 % get — typical read-light monitoring workload
+BENCHMARK_DEFINE_F(CMSFixture, Mixed)(benchmark::State& state) {
+    int64_t i = 0;
+    for (auto _ : state) {
+        const std::string& k = (*keys)[(*seq)[i % SEQ_LEN]];
+        if (i % 5 == 0) benchmark::DoNotOptimize(sketch->get(k));
+        else             sketch->inc(k, 1);
+        ++i;
+    }
+    state.SetItemsProcessed(state.iterations());
+}
 
-// ---------- ExponentialHistorgram --------------------------------------------
+// -- Inc: uniform, three key domains, two sketch sizes ----------------------
+BENCHMARK_REGISTER_F(CMSFixture, Inc)->Args({ 500, 3, 0, 0})->Name("CMS/Inc/w500d3/uniform/1K");
+BENCHMARK_REGISTER_F(CMSFixture, Inc)->Args({2000, 5, 0, 0})->Name("CMS/Inc/w2000d5/uniform/1K");
+BENCHMARK_REGISTER_F(CMSFixture, Inc)->Args({ 500, 3, 1, 0})->Name("CMS/Inc/w500d3/uniform/10K");
+BENCHMARK_REGISTER_F(CMSFixture, Inc)->Args({2000, 5, 1, 0})->Name("CMS/Inc/w2000d5/uniform/10K");
+BENCHMARK_REGISTER_F(CMSFixture, Inc)->Args({ 500, 3, 2, 0})->Name("CMS/Inc/w500d3/uniform/100K");
+BENCHMARK_REGISTER_F(CMSFixture, Inc)->Args({2000, 5, 2, 0})->Name("CMS/Inc/w2000d5/uniform/100K");
+BENCHMARK_REGISTER_F(CMSFixture, Inc)->Args({5000, 7, 2, 0})->Name("CMS/Inc/w5000d7/uniform/100K");
+// -- Inc: Zipf — same sketch sizes, shows hot-key cache effect ---------------
+BENCHMARK_REGISTER_F(CMSFixture, Inc)->Args({ 500, 3, 0, 1})->Name("CMS/Inc/w500d3/zipf/1K");
+BENCHMARK_REGISTER_F(CMSFixture, Inc)->Args({ 500, 3, 1, 1})->Name("CMS/Inc/w500d3/zipf/10K");
+BENCHMARK_REGISTER_F(CMSFixture, Inc)->Args({2000, 5, 1, 1})->Name("CMS/Inc/w2000d5/zipf/10K");
+BENCHMARK_REGISTER_F(CMSFixture, Inc)->Args({ 500, 3, 2, 1})->Name("CMS/Inc/w500d3/zipf/100K");
+BENCHMARK_REGISTER_F(CMSFixture, Inc)->Args({2000, 5, 2, 1})->Name("CMS/Inc/w2000d5/zipf/100K");
+// -- Get ----------------------------------------------------------------------
+BENCHMARK_REGISTER_F(CMSFixture, Get)->Args({ 500, 3, 1, 0})->Name("CMS/Get/w500d3/uniform/10K");
+BENCHMARK_REGISTER_F(CMSFixture, Get)->Args({2000, 5, 1, 0})->Name("CMS/Get/w2000d5/uniform/10K");
+BENCHMARK_REGISTER_F(CMSFixture, Get)->Args({ 500, 3, 1, 1})->Name("CMS/Get/w500d3/zipf/10K");
+BENCHMARK_REGISTER_F(CMSFixture, Get)->Args({2000, 5, 2, 1})->Name("CMS/Get/w2000d5/zipf/100K");
+// -- Mixed --------------------------------------------------------------------
+BENCHMARK_REGISTER_F(CMSFixture, Mixed)->Args({2000, 5, 1, 0})->Name("CMS/Mixed/w2000d5/uniform/10K");
+BENCHMARK_REGISTER_F(CMSFixture, Mixed)->Args({2000, 5, 1, 1})->Name("CMS/Mixed/w2000d5/zipf/10K");
+BENCHMARK_REGISTER_F(CMSFixture, Mixed)->Args({2000, 5, 2, 1})->Name("CMS/Mixed/w2000d5/zipf/100K");
 
-class ExponentialHistorgramFixture : public benchmark::Fixture {
+// ============================================================================
+// ExponentialHistorgram
+//
+// Parameters (via state.range):
+//   [0] window     — sliding window size
+//   [1] tick_step  — tick increment per operation
+//
+// tick_step is the key variable: how far the stream advances between calls.
+//   step = 1           → steady stream, minimal bucket reshuffling (hot path)
+//   step = window / 4  → bursty, several buckets shift each call
+//   step = window / 2  → heavy churn, most stored data expires on every call
+//
+// This directly reveals the cost of the internal bucket-cascade algorithm
+// across realistic operating points.
+// ============================================================================
+
+class EHFixture : public benchmark::Fixture {
 public:
     std::unique_ptr<ExponentialHistorgram<int>> eh;
 
     void SetUp(const benchmark::State& state) override {
-        uint32_t window = static_cast<uint32_t>(state.range(0));
-        eh = std::make_unique<ExponentialHistorgram<int>>(window);
-        for (uint32_t t = 0; t < 64; ++t) {
-            eh->inc(t, 1);
-        }
+        eh = std::make_unique<ExponentialHistorgram<int>>(
+                 static_cast<uint32_t>(state.range(0)));
+        for (uint32_t t = 0; t < 128; ++t) eh->inc(t, 1);
     }
 
-    void TearDown(const benchmark::State&) override {
-        eh.reset();
-    }
+    void TearDown(const benchmark::State&) override { eh.reset(); }
 };
 
-BENCHMARK_DEFINE_F(ExponentialHistorgramFixture, Inc)(benchmark::State& state) {
-    uint32_t tick = 1000;
+BENCHMARK_DEFINE_F(EHFixture, Inc)(benchmark::State& state) {
+    uint32_t step = static_cast<uint32_t>(state.range(1));
+    uint32_t tick = 2000;
     for (auto _ : state) {
         eh->inc(tick, 1);
-        ++tick;
+        tick += step;
     }
     state.SetItemsProcessed(state.iterations());
 }
 
-BENCHMARK_DEFINE_F(ExponentialHistorgramFixture, Get)(benchmark::State& state) {
+BENCHMARK_DEFINE_F(EHFixture, Get)(benchmark::State& state) {
     uint32_t window = static_cast<uint32_t>(state.range(0));
-    uint32_t tick   = 1000;
+    uint32_t step   = static_cast<uint32_t>(state.range(1));
+    uint32_t tick   = 2000;
     for (auto _ : state) {
         benchmark::DoNotOptimize(eh->get(window / 2, tick));
-        ++tick;
+        tick += step;
     }
     state.SetItemsProcessed(state.iterations());
 }
 
-// window
-BENCHMARK_REGISTER_F(ExponentialHistorgramFixture, Inc)->Arg(64);
-BENCHMARK_REGISTER_F(ExponentialHistorgramFixture, Inc)->Arg(1024);
-BENCHMARK_REGISTER_F(ExponentialHistorgramFixture, Inc)->Arg(16384);
-BENCHMARK_REGISTER_F(ExponentialHistorgramFixture, Get)->Arg(64);
-BENCHMARK_REGISTER_F(ExponentialHistorgramFixture, Get)->Arg(1024);
-BENCHMARK_REGISTER_F(ExponentialHistorgramFixture, Get)->Arg(16384);
+// window, tick_step
+// Steady stream (tick_step = 1)
+BENCHMARK_REGISTER_F(EHFixture, Inc)->Args({  256,    1})->Name("EH/Inc/w256/steady");
+BENCHMARK_REGISTER_F(EHFixture, Inc)->Args({ 1024,    1})->Name("EH/Inc/w1024/steady");
+BENCHMARK_REGISTER_F(EHFixture, Inc)->Args({16384,    1})->Name("EH/Inc/w16384/steady");
+// Bursty stream (tick_step = window / 4)
+BENCHMARK_REGISTER_F(EHFixture, Inc)->Args({  256,   64})->Name("EH/Inc/w256/bursty");
+BENCHMARK_REGISTER_F(EHFixture, Inc)->Args({ 1024,  256})->Name("EH/Inc/w1024/bursty");
+BENCHMARK_REGISTER_F(EHFixture, Inc)->Args({16384, 4096})->Name("EH/Inc/w16384/bursty");
+// High-churn (tick_step = window / 2 → most data expires each call)
+BENCHMARK_REGISTER_F(EHFixture, Inc)->Args({  256,  128})->Name("EH/Inc/w256/expiry");
+BENCHMARK_REGISTER_F(EHFixture, Inc)->Args({ 1024,  512})->Name("EH/Inc/w1024/expiry");
+BENCHMARK_REGISTER_F(EHFixture, Inc)->Args({16384, 8192})->Name("EH/Inc/w16384/expiry");
 
-// ---------- ExponentialCountMinSketch ----------------------------------------
+BENCHMARK_REGISTER_F(EHFixture, Get)->Args({  256,    1})->Name("EH/Get/w256/steady");
+BENCHMARK_REGISTER_F(EHFixture, Get)->Args({ 1024,    1})->Name("EH/Get/w1024/steady");
+BENCHMARK_REGISTER_F(EHFixture, Get)->Args({16384,    1})->Name("EH/Get/w16384/steady");
+BENCHMARK_REGISTER_F(EHFixture, Get)->Args({ 1024,  256})->Name("EH/Get/w1024/bursty");
+BENCHMARK_REGISTER_F(EHFixture, Get)->Args({16384, 4096})->Name("EH/Get/w16384/bursty");
+BENCHMARK_REGISTER_F(EHFixture, Get)->Args({ 1024,  512})->Name("EH/Get/w1024/expiry");
 
-class ECMSketchFixture : public benchmark::Fixture {
+// ============================================================================
+// ExponentialCountMinSketch
+//
+// Parameters (via state.range):
+//   [0] width     — sketch width
+//   [1] depth     — number of hash functions
+//   [2] window    — sliding window size
+//   [3] tick_step — tick increment (1=steady, larger=bursty)
+//   [4] pool_id   — key domain: 0=1K, 1=10K, 2=100K
+//   [5] dist_id   — access pattern: 0=uniform, 1=zipf
+// ============================================================================
+
+class ECMFixture : public benchmark::Fixture {
 public:
     std::unique_ptr<ExponentialCountMinSketch<int>> sketch;
-    uint32_t window_;
+    const std::vector<std::string>* keys = nullptr;
+    const std::vector<int>*         seq  = nullptr;
+    uint32_t window_ = 0;
+    uint32_t step_   = 1;
 
     void SetUp(const benchmark::State& state) override {
-        InitKeys();
-        uint32_t width = static_cast<uint32_t>(state.range(0));
-        uint8_t  depth = static_cast<uint8_t>(state.range(1));
-        window_        = static_cast<uint32_t>(state.range(2));
-        sketch = std::make_unique<ExponentialCountMinSketch<int>>(width, depth, window_);
-        for (int i = 0; i < KEY_POOL_SIZE; ++i) {
-            sketch->inc(g_keys[i], static_cast<uint32_t>(i), 1);
-        }
+        InitGlobals();
+        window_ = static_cast<uint32_t>(state.range(2));
+        step_   = static_cast<uint32_t>(state.range(3));
+        keys    = &KeyPool(state.range(4));
+        seq     = &AccessSeq(state.range(4), state.range(5));
+        sketch  = std::make_unique<ExponentialCountMinSketch<int>>(
+                      static_cast<uint32_t>(state.range(0)),
+                      static_cast<uint8_t> (state.range(1)),
+                      window_);
+        for (size_t i = 0; i < keys->size(); ++i)
+            sketch->inc((*keys)[i], static_cast<uint32_t>(i), 1);
     }
 
-    void TearDown(const benchmark::State&) override {
-        sketch.reset();
-    }
+    void TearDown(const benchmark::State&) override { sketch.reset(); }
 };
 
-BENCHMARK_DEFINE_F(ECMSketchFixture, Inc)(benchmark::State& state) {
-    uint32_t tick = KEY_POOL_SIZE + 1;
+BENCHMARK_DEFINE_F(ECMFixture, Inc)(benchmark::State& state) {
+    uint32_t tick = static_cast<uint32_t>(keys->size()) + 1;
     int64_t  i    = 0;
     for (auto _ : state) {
-        sketch->inc(g_keys[i % KEY_POOL_SIZE], tick, 1);
-        ++tick;
+        sketch->inc((*keys)[(*seq)[i % SEQ_LEN]], tick, 1);
+        tick += step_;
         ++i;
     }
     state.SetItemsProcessed(state.iterations());
 }
 
-BENCHMARK_DEFINE_F(ECMSketchFixture, Get)(benchmark::State& state) {
-    uint32_t tick = KEY_POOL_SIZE + 1;
+BENCHMARK_DEFINE_F(ECMFixture, Get)(benchmark::State& state) {
+    uint32_t tick = static_cast<uint32_t>(keys->size()) + 1;
     int64_t  i    = 0;
     for (auto _ : state) {
-        benchmark::DoNotOptimize(sketch->get(g_keys[i % KEY_POOL_SIZE], window_ / 2, tick));
-        ++tick;
+        benchmark::DoNotOptimize(
+            sketch->get((*keys)[(*seq)[i % SEQ_LEN]], window_ / 2, tick));
+        tick += step_;
         ++i;
     }
     state.SetItemsProcessed(state.iterations());
 }
 
-// width, depth, window
-BENCHMARK_REGISTER_F(ECMSketchFixture, Inc)->Args({100,  3,   64});
-BENCHMARK_REGISTER_F(ECMSketchFixture, Inc)->Args({1000, 5, 1024});
-BENCHMARK_REGISTER_F(ECMSketchFixture, Inc)->Args({5000, 7, 4096});
-BENCHMARK_REGISTER_F(ECMSketchFixture, Get)->Args({100,  3,   64});
-BENCHMARK_REGISTER_F(ECMSketchFixture, Get)->Args({1000, 5, 1024});
-BENCHMARK_REGISTER_F(ECMSketchFixture, Get)->Args({5000, 7, 4096});
+// 80 % inc / 20 % get
+BENCHMARK_DEFINE_F(ECMFixture, Mixed)(benchmark::State& state) {
+    uint32_t tick = static_cast<uint32_t>(keys->size()) + 1;
+    int64_t  i    = 0;
+    for (auto _ : state) {
+        const std::string& k = (*keys)[(*seq)[i % SEQ_LEN]];
+        if (i % 5 == 0) benchmark::DoNotOptimize(sketch->get(k, window_ / 2, tick));
+        else             sketch->inc(k, tick, 1);
+        tick += step_;
+        ++i;
+    }
+    state.SetItemsProcessed(state.iterations());
+}
+
+// width, depth, window, tick_step, pool_id, dist_id
+// -- Steady stream, uniform ---------------------------------------------------
+BENCHMARK_REGISTER_F(ECMFixture, Inc)
+    ->Args({ 500, 3,  256, 1, 0, 0})->Name("ECM/Inc/w500d3win256/steady/uniform/1K");
+BENCHMARK_REGISTER_F(ECMFixture, Inc)
+    ->Args({ 500, 3, 1024, 1, 1, 0})->Name("ECM/Inc/w500d3win1024/steady/uniform/10K");
+BENCHMARK_REGISTER_F(ECMFixture, Inc)
+    ->Args({2000, 5, 1024, 1, 1, 0})->Name("ECM/Inc/w2000d5win1024/steady/uniform/10K");
+BENCHMARK_REGISTER_F(ECMFixture, Inc)
+    ->Args({2000, 5, 4096, 1, 2, 0})->Name("ECM/Inc/w2000d5win4096/steady/uniform/100K");
+// -- Steady stream, Zipf — hot keys stay warm in EH buckets ------------------
+BENCHMARK_REGISTER_F(ECMFixture, Inc)
+    ->Args({ 500, 3, 1024, 1, 1, 1})->Name("ECM/Inc/w500d3win1024/steady/zipf/10K");
+BENCHMARK_REGISTER_F(ECMFixture, Inc)
+    ->Args({2000, 5, 1024, 1, 1, 1})->Name("ECM/Inc/w2000d5win1024/steady/zipf/10K");
+BENCHMARK_REGISTER_F(ECMFixture, Inc)
+    ->Args({2000, 5, 4096, 1, 2, 1})->Name("ECM/Inc/w2000d5win4096/steady/zipf/100K");
+// -- Bursty stream — reveals sliding-window maintenance overhead --------------
+BENCHMARK_REGISTER_F(ECMFixture, Inc)
+    ->Args({ 500, 3, 1024, 256, 1, 0})->Name("ECM/Inc/w500d3win1024/bursty/uniform/10K");
+BENCHMARK_REGISTER_F(ECMFixture, Inc)
+    ->Args({2000, 5, 1024, 256, 1, 0})->Name("ECM/Inc/w2000d5win1024/bursty/uniform/10K");
+BENCHMARK_REGISTER_F(ECMFixture, Inc)
+    ->Args({2000, 5, 1024, 256, 1, 1})->Name("ECM/Inc/w2000d5win1024/bursty/zipf/10K");
+// -- Get ----------------------------------------------------------------------
+BENCHMARK_REGISTER_F(ECMFixture, Get)
+    ->Args({ 500, 3, 1024, 1, 1, 0})->Name("ECM/Get/w500d3win1024/steady/uniform/10K");
+BENCHMARK_REGISTER_F(ECMFixture, Get)
+    ->Args({2000, 5, 1024, 1, 1, 1})->Name("ECM/Get/w2000d5win1024/steady/zipf/10K");
+BENCHMARK_REGISTER_F(ECMFixture, Get)
+    ->Args({ 500, 3, 1024, 256, 1, 0})->Name("ECM/Get/w500d3win1024/bursty/uniform/10K");
+BENCHMARK_REGISTER_F(ECMFixture, Get)
+    ->Args({2000, 5, 4096, 1, 2, 1})->Name("ECM/Get/w2000d5win4096/steady/zipf/100K");
+// -- Mixed --------------------------------------------------------------------
+BENCHMARK_REGISTER_F(ECMFixture, Mixed)
+    ->Args({ 500, 3, 1024,   1, 1, 0})->Name("ECM/Mixed/w500d3win1024/steady/uniform/10K");
+BENCHMARK_REGISTER_F(ECMFixture, Mixed)
+    ->Args({2000, 5, 1024,   1, 1, 1})->Name("ECM/Mixed/w2000d5win1024/steady/zipf/10K");
+BENCHMARK_REGISTER_F(ECMFixture, Mixed)
+    ->Args({ 500, 3, 1024, 256, 1, 0})->Name("ECM/Mixed/w500d3win1024/bursty/uniform/10K");
+
+// ============================================================================
+// End-to-end scenarios
+//
+// These simulate realistic workloads rather than isolating a single operation.
+// ============================================================================
+
+// Scenario: frequency estimation over a large, Zipf-distributed domain.
+// Models a system counting how often each event (URL, user, product) appears
+// in a stream.  90 % inserts, 10 % point queries (e.g., "is this key hot?").
+static void BM_FrequencyEstimation(benchmark::State& state) {
+    InitGlobals();
+    CountMinSketch<int> sketch(5000, 5);
+    for (int i = 0; i < SEQ_LEN; ++i)
+        sketch.inc(g_keys_large[g_zipf_large[i]], 1);
+
+    int64_t i = 0;
+    for (auto _ : state) {
+        sketch.inc(g_keys_large[g_zipf_large[i % SEQ_LEN]], 1);
+        if (i % 10 == 0)
+            benchmark::DoNotOptimize(sketch.get(g_keys_large[g_zipf_large[i % SEQ_LEN]]));
+        ++i;
+    }
+    state.SetItemsProcessed(state.iterations());
+}
+BENCHMARK(BM_FrequencyEstimation)->Name("Scenario/FrequencyEstimation/zipf/100K");
+
+// Scenario: heavy-hitter detection in a sliding window.
+// Simulates a monitoring system tracking per-key frequency in the last N events
+// (e.g., detecting DDoS sources, trending topics, or slow queries).
+// Every 10 inserts, queries the current key and flags it as a heavy hitter
+// if its count exceeds 1 % of the window size.
+static void BM_HeavyHitterDetection(benchmark::State& state) {
+    InitGlobals();
+    const uint32_t window    = 2048;
+    const int      threshold = static_cast<int>(window * 0.01);
+    ExponentialCountMinSketch<int> sketch(1000, 5, window);
+    for (size_t i = 0; i < g_keys_medium.size(); ++i)
+        sketch.inc(g_keys_medium[i], static_cast<uint32_t>(i), 1);
+
+    uint32_t tick         = static_cast<uint32_t>(g_keys_medium.size()) + 1;
+    int64_t  i            = 0;
+    int64_t  heavy_hitters = 0;
+    for (auto _ : state) {
+        const std::string& k = g_keys_medium[g_zipf_medium[i % SEQ_LEN]];
+        sketch.inc(k, tick, 1);
+        if (i % 10 == 0) {
+            int cnt = sketch.get(k, window, tick);
+            if (cnt > threshold) ++heavy_hitters;
+        }
+        ++tick;
+        ++i;
+    }
+    state.SetItemsProcessed(state.iterations());
+    state.counters["heavy_hitters_pct"] =
+        benchmark::Counter(static_cast<double>(heavy_hitters) /
+                           static_cast<double>(state.iterations()) * 100.0);
+}
+BENCHMARK(BM_HeavyHitterDetection)->Name("Scenario/HeavyHitterDetection/zipf/10K");
+
+// Scenario: sliding-window rate limiter.
+// Each tick represents one second.  For every request (key = client ID),
+// the system checks whether the client has exceeded R requests in the last W
+// seconds.  Mirrors rate-limiting and quota enforcement use cases.
+static void BM_RateLimiter(benchmark::State& state) {
+    InitGlobals();
+    const uint32_t window        = 60;   // 60-second sliding window
+    const int      rate_limit    = 10;   // max 10 requests per window
+    ExponentialCountMinSketch<int> sketch(2000, 5, window);
+    for (size_t i = 0; i < g_keys_medium.size(); ++i)
+        sketch.inc(g_keys_medium[i], static_cast<uint32_t>(i % window), 1);
+
+    uint32_t tick      = static_cast<uint32_t>(g_keys_medium.size()) + 1;
+    int64_t  i         = 0;
+    int64_t  throttled = 0;
+    for (auto _ : state) {
+        const std::string& k = g_keys_medium[g_zipf_medium[i % SEQ_LEN]];
+        int rate = sketch.get(k, window, tick);
+        if (rate < rate_limit) {
+            sketch.inc(k, tick, 1);
+        } else {
+            ++throttled;
+        }
+        if (i % 10 == 0) ++tick;   // advance clock every 10 requests
+        ++i;
+    }
+    state.SetItemsProcessed(state.iterations());
+    state.counters["throttled_pct"] =
+        benchmark::Counter(static_cast<double>(throttled) /
+                           static_cast<double>(state.iterations()) * 100.0);
+}
+BENCHMARK(BM_RateLimiter)->Name("Scenario/RateLimiter/zipf/10K");

--- a/docs/benchmarks.rst
+++ b/docs/benchmarks.rst
@@ -1,0 +1,113 @@
+Benchmarks
+==========
+
+ProbStructs ships a `Google Benchmark`_ suite that measures ``inc`` and ``get``
+performance for all three data structures across a range of parameter sizes.
+Results are saved as JSON so you can track performance across commits.
+
+.. _Google Benchmark: https://github.com/google/benchmark
+
+Building
+--------
+
+Benchmarks are **off by default** and live in their own CMake build directory
+``_bench`` so they never slow down a normal debug or release build.
+
+.. code-block:: bash
+
+    make bench-build
+
+This runs ``cmake`` with ``-DCMAKE_BUILD_TYPE=Release -DBUILD_BENCHMARKS=ON``,
+fetches Google Benchmark via ``FetchContent``, and compiles
+``_bench/benchmarks/probstructs_benchmark``.
+
+Running
+-------
+
+.. code-block:: bash
+
+    make bench-run
+
+The script ``scripts/bench_run.sh`` executes the binary and writes a
+timestamped JSON file to ``benchmark_results/``::
+
+    benchmark_results/2026-05-27_14-30-00.json
+
+The file is committed to the repository so the run history is preserved.
+
+You can pass extra Google Benchmark flags after the target:
+
+.. code-block:: bash
+
+    ./scripts/bench_run.sh _bench/benchmarks/probstructs_benchmark \
+        --benchmark_filter=CountMin \
+        --benchmark_repetitions=5
+
+Comparing runs
+--------------
+
+After two or more runs:
+
+.. code-block:: bash
+
+    make bench-compare
+
+This calls ``scripts/bench_compare.sh``, which locates Google Benchmark's
+``tools/compare.py`` inside the ``_bench`` build directory and compares the
+two most-recent result files automatically.
+
+To compare specific files:
+
+.. code-block:: bash
+
+    ./scripts/bench_compare.sh \
+        benchmark_results/2026-05-20_10-00-00.json \
+        benchmark_results/2026-05-27_14-30-00.json
+
+The comparison output shows the relative change (``+``/``-``) for each
+benchmark, making regressions easy to spot.
+
+What is benchmarked
+-------------------
+
+Each data structure is benchmarked for both ``inc`` (insert) and ``get``
+(query) with three parameter sizes:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 20 20 20 10
+
+   * - Structure
+     - Small
+     - Medium
+     - Large
+     - Operations
+   * - ``CountMinSketch``
+     - width=100, depth=3
+     - width=1000, depth=5
+     - width=10000, depth=7
+     - inc, get
+   * - ``ExponentialHistorgram``
+     - window=64
+     - window=1024
+     - window=16384
+     - inc, get
+   * - ``ExponentialCountMinSketch``
+     - width=100, depth=3, window=64
+     - width=1000, depth=5, window=1024
+     - width=5000, depth=7, window=4096
+     - inc, get
+
+All benchmarks report **items/s** throughput in addition to wall time.
+
+CMake option reference
+----------------------
+
+``BUILD_BENCHMARKS``
+    Set to ``ON`` to include the ``benchmarks/`` subdirectory.
+    Default: ``OFF``.
+
+``MODERN_CMAKE_BUILD_BENCHMARKS``
+    Emergency override to enable benchmarks when ProbStructs is consumed
+    via ``add_subdirectory`` from another project.
+    Default: not set.

--- a/docs/benchmarks.rst
+++ b/docs/benchmarks.rst
@@ -7,6 +7,27 @@ Results are saved as JSON so you can track performance across commits.
 
 .. _Google Benchmark: https://github.com/google/benchmark
 
+Prerequisites
+-------------
+
+You need **CMake 3.11+** and a C++17-capable compiler.  The Makefile finds
+cmake automatically in ``PATH`` and the common Homebrew locations
+(``/opt/homebrew/bin``, ``/usr/local/bin``).
+
+macOS:
+
+.. code-block:: bash
+
+    brew install cmake
+
+Ubuntu/Debian:
+
+.. code-block:: bash
+
+    # Kitware's APT repository provides a current release:
+    # https://apt.kitware.com/
+    sudo apt-get install cmake
+
 Building
 --------
 

--- a/docs/benchmarks.rst
+++ b/docs/benchmarks.rst
@@ -186,6 +186,37 @@ Models API rate limiting and quota enforcement.  Reports ``throttled_pct``.
 
 All benchmarks report **items/s** throughput in addition to wall time.
 
+Continuous integration
+----------------------
+
+The ``CI`` GitHub Actions workflow (``.github/workflows/ci.yml``) runs
+automatically on every pull request and push to ``master``:
+
+* **Unit tests** — built and run on Ubuntu and macOS.  A failure blocks the PR.
+
+* **Benchmark regression check** — benchmarks are built and run on a fixed
+  Ubuntu runner for consistency.  The latest JSON file committed to ``master``
+  is used as the baseline.  If any benchmark is more than **5 %** slower the
+  workflow fails and the PR is blocked.
+
+* **Baseline update** — on pushes to ``master`` the new result file is
+  automatically committed to ``benchmark_results/`` so future PRs always
+  compare against up-to-date hardware measurements.
+
+.. note::
+
+   GitHub Actions runners are virtualised.  Timing can vary by ±2–3 % between
+   runs.  The 5 % threshold provides headroom for that noise.  If the check
+   becomes flaky on your setup, widen it by changing the ``--threshold``
+   argument in the workflow file.
+
+You can also run the regression check locally::
+
+    python3 scripts/bench_check_regression.py \
+        --baseline benchmark_results/2026-05-20_10-00-00.json \
+        --current  benchmark_results/2026-05-27_14-30-00.json \
+        --threshold 5
+
 CMake option reference
 ----------------------
 

--- a/docs/benchmarks.rst
+++ b/docs/benchmarks.rst
@@ -22,9 +22,14 @@ The CI workflow saves to ``ci/`` automatically.
 Prerequisites
 -------------
 
-You need **CMake 3.11+** and a C++17-capable compiler.  The Makefile finds
-cmake automatically in ``PATH`` and the common Homebrew locations
-(``/opt/homebrew/bin``, ``/usr/local/bin``).
+You need **CMake 3.11+**, a C++17-capable compiler, and **uv** (used to run
+the comparison and regression scripts with their dependencies fetched
+automatically).
+
+Install uv: https://docs.astral.sh/uv/getting-started/installation/
+
+The Makefile finds cmake automatically in ``PATH`` and the common Homebrew
+locations (``/opt/homebrew/bin``, ``/usr/local/bin``).
 
 macOS:
 
@@ -62,11 +67,12 @@ Running
     make bench-run
 
 The script ``scripts/bench_run.sh`` executes the binary and writes a
-timestamped JSON file to ``benchmark_results/``::
+timestamped JSON file to ``benchmark_results/local/``::
 
-    benchmark_results/2026-05-27_14-30-00.json
+    benchmark_results/local/2026-05-27_14-30-00.json
 
-The file is committed to the repository so the run history is preserved.
+Local results are gitignored; they are only used for local comparisons.
+See *Result storage* above.
 
 You can pass extra Google Benchmark flags after the target:
 
@@ -87,15 +93,17 @@ After two or more runs:
 
 This calls ``scripts/bench_compare.sh``, which locates Google Benchmark's
 ``tools/compare.py`` inside the ``_bench`` build directory and compares the
-two most-recent result files automatically.
+two most-recent files in ``benchmark_results/local/`` automatically.
+The required Python packages (``numpy``, ``scipy``) are fetched via **uv**
+on the first run — no manual ``pip install`` needed.
 
 To compare specific files:
 
 .. code-block:: bash
 
     ./scripts/bench_compare.sh \
-        benchmark_results/2026-05-20_10-00-00.json \
-        benchmark_results/2026-05-27_14-30-00.json
+        benchmark_results/local/2026-05-20_10-00-00.json \
+        benchmark_results/local/2026-05-27_14-30-00.json
 
 The comparison output shows the relative change (``+``/``-``) for each
 benchmark, making regressions easy to spot.
@@ -204,30 +212,35 @@ Continuous integration
 The ``CI`` GitHub Actions workflow (``.github/workflows/ci.yml``) runs
 automatically on every pull request and push to ``master``:
 
-* **Unit tests** — built and run on Ubuntu and macOS.  A failure blocks the PR.
+* **Unit tests** — built and run on Ubuntu, macOS, and Windows.  A failure
+  blocks the PR.
 
 * **Benchmark regression check** — benchmarks are built and run on a fixed
-  Ubuntu runner for consistency.  The latest JSON file committed to ``master``
-  is used as the baseline.  If any benchmark is more than **5 %** slower the
+  Ubuntu runner for consistency, with ``--benchmark_repetitions=3`` so the
+  comparison uses the statistical mean rather than a single sample.  The
+  latest JSON file committed to ``master`` (in ``benchmark_results/ci/``) is
+  used as the baseline.  If any benchmark is more than **10 %** slower the
   workflow fails and the PR is blocked.
 
 * **Baseline update** — on pushes to ``master`` the new result file is
-  automatically committed to ``benchmark_results/`` so future PRs always
+  automatically committed to ``benchmark_results/ci/`` so future PRs always
   compare against up-to-date hardware measurements.
 
 .. note::
 
-   GitHub Actions runners are virtualised.  Timing can vary by ±2–3 % between
-   runs.  The 5 % threshold provides headroom for that noise.  If the check
-   becomes flaky on your setup, widen it by changing the ``--threshold``
-   argument in the workflow file.
+   GitHub Actions runners are virtualised.  Timing can vary by ±5 % between
+   runs.  Three repetitions and the 10 % threshold together provide headroom
+   for that noise.  If the check becomes flaky, widen ``--threshold`` in the
+   workflow file.
 
-You can also run the regression check locally::
+You can also run the regression check locally:
 
-    python3 scripts/bench_check_regression.py \
-        --baseline benchmark_results/2026-05-20_10-00-00.json \
-        --current  benchmark_results/2026-05-27_14-30-00.json \
-        --threshold 5
+.. code-block:: bash
+
+    uv run scripts/bench_check_regression.py \
+        --baseline benchmark_results/ci/2026-05-20_10-00-00.json \
+        --current  benchmark_results/local/2026-05-27_14-30-00.json \
+        --threshold 10
 
 CMake option reference
 ----------------------

--- a/docs/benchmarks.rst
+++ b/docs/benchmarks.rst
@@ -5,6 +5,18 @@ ProbStructs ships a `Google Benchmark`_ suite that measures ``inc`` and ``get``
 performance for all three data structures across a range of parameter sizes.
 Results are saved as JSON so you can track performance across commits.
 
+Result storage
+--------------
+
+Results are kept in two separate directories so local and CI runs never mix:
+
+* ``benchmark_results/local/`` — your local runs; **gitignored** (never committed)
+* ``benchmark_results/ci/`` — CI runs committed to ``master``; used as the
+  regression baseline for pull requests
+
+``make bench-run`` and ``make bench-compare`` always target ``local/``.
+The CI workflow saves to ``ci/`` automatically.
+
 .. _Google Benchmark: https://github.com/google/benchmark
 
 Prerequisites

--- a/docs/benchmarks.rst
+++ b/docs/benchmarks.rst
@@ -91,33 +91,98 @@ benchmark, making regressions easy to spot.
 What is benchmarked
 -------------------
 
-Each data structure is benchmarked for both ``inc`` (insert) and ``get``
-(query) with three parameter sizes:
+Key domains
+~~~~~~~~~~~
+
+All benchmarks use pre-generated key pools and access sequences to avoid
+measuring string construction inside the timed loop:
 
 .. list-table::
    :header-rows: 1
-   :widths: 30 20 20 20 10
+   :widths: 20 15 65
 
-   * - Structure
-     - Small
-     - Medium
-     - Large
-     - Operations
-   * - ``CountMinSketch``
-     - width=100, depth=3
-     - width=1000, depth=5
-     - width=10000, depth=7
-     - inc, get
-   * - ``ExponentialHistorgram``
-     - window=64
-     - window=1024
-     - window=16384
-     - inc, get
-   * - ``ExponentialCountMinSketch``
-     - width=100, depth=3, window=64
-     - width=1000, depth=5, window=1024
-     - width=5000, depth=7, window=4096
-     - inc, get
+   * - Name
+     - Keys
+     - Purpose
+   * - Small
+     - 1 000
+     - High collision rate; sketch data fits in L1/L2 cache
+   * - Medium
+     - 10 000
+     - Moderate collisions; L2/L3 resident
+   * - Large
+     - 100 000
+     - Low collision rate; exercises cache pressure
+
+Access distributions
+~~~~~~~~~~~~~~~~~~~~
+
+* **Uniform** — every key equally likely (worst-case for accuracy, neutral for cache).
+* **Zipf (s=1)** — top 1 % of keys receive ~50 % of traffic.  Realistic for
+  web requests, event streams, and user activity logs.  Hot keys stay warm in
+  cache, which can reveal differences invisible under uniform load.
+
+CountMinSketch
+~~~~~~~~~~~~~~
+
+Benchmarks: ``Inc``, ``Get``, ``Mixed`` (80 % inc / 20 % get).
+
+Parameters swept: sketch width (500 – 5 000), depth (3 – 7), key domain
+(1 K – 100 K), distribution (uniform / Zipf).  The full sketch size
+(``width × depth × 4`` bytes) spans from well within L1 cache to L3-resident,
+making the parameter sweep a de-facto cache-pressure study.
+
+ExponentialHistorgram
+~~~~~~~~~~~~~~~~~~~~~
+
+Benchmarks: ``Inc``, ``Get``.
+
+The key variable is **tick_step** — how far the stream clock advances between
+calls.  This controls how much internal bucket-cascade work each call triggers:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 60
+
+   * - Mode
+     - tick_step
+     - Meaning
+   * - Steady
+     - 1
+     - Minimal reshuffling — hot path for continuous streams
+   * - Bursty
+     - window / 4
+     - Several buckets shift per call
+   * - Expiry
+     - window / 2
+     - Majority of stored data expires on every call
+
+Windows tested: 256, 1 024, 16 384.
+
+ExponentialCountMinSketch
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Benchmarks: ``Inc``, ``Get``, ``Mixed`` (80 % inc / 20 % get).
+
+Parameters swept: sketch width (500 – 2 000), depth (3 – 5), window
+(256 – 4 096), tick_step (steady / bursty), key domain (1 K – 100 K),
+distribution (uniform / Zipf).
+
+End-to-end scenarios
+~~~~~~~~~~~~~~~~~~~~
+
+These simulate realistic workloads rather than isolating a single operation:
+
+**FrequencyEstimation** — 90 % inserts / 10 % point queries over a 100 K Zipf
+key domain.  Models event counting (URL hits, product views).
+
+**HeavyHitterDetection** — Sliding-window frequency counting over a 10 K Zipf
+domain.  Every 10 inserts the current key is queried; keys exceeding 1 % of
+the window are flagged.  Reports ``heavy_hitters_pct`` as a counter.
+
+**RateLimiter** — Per-client request rate checking against a 60-second sliding
+window.  Each event is either counted (if under the rate limit) or dropped.
+Models API rate limiting and quota enforcement.  Reports ``throttled_pct``.
 
 All benchmarks report **items/s** throughput in addition to wall time.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,7 +20,7 @@ Example
 
     ExponentialCountMinSketch<int> sketch(100, 4, 8);
 
-    uint ts = 0;
+    uint32_t ts = 0;
 
     ts = 0;
     sketch.inc("aaa", ts, 1);

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -68,5 +68,6 @@ Wrappers
    :caption: Contents:
 
    classes
+   benchmarks
 
 :ref:`genindex`

--- a/scripts/bench_check_regression.py
+++ b/scripts/bench_check_regression.py
@@ -1,4 +1,8 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.8"
+# dependencies = []
+# ///
 """Fail with exit code 1 if any benchmark regressed beyond the given threshold.
 
 Compares cpu_time from two Google Benchmark JSON result files.

--- a/scripts/bench_check_regression.py
+++ b/scripts/bench_check_regression.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Fail with exit code 1 if any benchmark regressed beyond the given threshold.
+
+Compares cpu_time from two Google Benchmark JSON result files.
+Benchmarks present in only one file are silently skipped (new or removed).
+
+Usage:
+    python3 bench_check_regression.py \
+        --baseline old.json --current new.json [--threshold 5]
+"""
+
+import argparse
+import json
+import sys
+
+
+def load_results(path):
+    """Return a dict name→benchmark for iteration or mean-aggregate entries."""
+    with open(path) as f:
+        data = json.load(f)
+    benchmarks = data.get("benchmarks", [])
+
+    # Prefer raw iteration results (single run, no --benchmark_repetitions).
+    by_name = {b["name"]: b for b in benchmarks if b.get("run_type") == "iteration"}
+    if by_name:
+        return by_name
+
+    # Fall back to mean aggregates (produced when --benchmark_repetitions > 1).
+    return {
+        b["name"]: b
+        for b in benchmarks
+        if b.get("run_type") == "aggregate" and b.get("aggregate_name") == "mean"
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--baseline",  required=True, help="Path to baseline JSON")
+    parser.add_argument("--current",   required=True, help="Path to current JSON")
+    parser.add_argument("--threshold", type=float, default=5.0,
+                        help="Maximum allowed slowdown in percent (default: 5)")
+    args = parser.parse_args()
+
+    baseline = load_results(args.baseline)
+    current  = load_results(args.current)
+
+    if not baseline:
+        print("WARNING: baseline file contains no usable results — skipping comparison.")
+        sys.exit(0)
+
+    threshold = args.threshold / 100.0
+    regressions = []
+    improvements = []
+    compared = 0
+
+    for name, cur in current.items():
+        if name not in baseline:
+            continue
+        base = baseline[name]
+        old_ns = base["cpu_time"]
+        new_ns = cur["cpu_time"]
+        if old_ns <= 0:
+            continue
+        compared += 1
+        ratio = (new_ns - old_ns) / old_ns
+        if ratio > threshold:
+            regressions.append((name, old_ns, new_ns, ratio * 100))
+        elif ratio < -threshold:
+            improvements.append((name, old_ns, new_ns, ratio * 100))
+
+    print(f"Compared {compared} benchmark(s) against baseline "
+          f"(threshold: ±{args.threshold:.0f}%).")
+
+    if improvements:
+        print(f"\n  {len(improvements)} improvement(s):")
+        for name, old, new, pct in sorted(improvements, key=lambda x: x[3]):
+            print(f"    {name}")
+            print(f"      {old:.2f} ns  →  {new:.2f} ns  ({pct:+.1f}%)")
+
+    if regressions:
+        print(f"\n  {len(regressions)} REGRESSION(S) above {args.threshold:.0f}% threshold:")
+        for name, old, new, pct in sorted(regressions, key=lambda x: -x[3]):
+            print(f"    {name}")
+            print(f"      {old:.2f} ns  →  {new:.2f} ns  ({pct:+.1f}%)")
+        print()
+        sys.exit(1)
+
+    print(f"  No regressions above {args.threshold:.0f}% threshold.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_compare.sh
+++ b/scripts/bench_compare.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RESULTS_DIR="benchmark_results"
+COMPARE_PY_SEARCH_PATHS=(
+    "_bench/_deps/googlebenchmark-src/tools/compare.py"
+    "_debug/_deps/googlebenchmark-src/tools/compare.py"
+    "_release/_deps/googlebenchmark-src/tools/compare.py"
+)
+
+COMPARE_PY=""
+for p in "${COMPARE_PY_SEARCH_PATHS[@]}"; do
+    if [[ -f "${p}" ]]; then
+        COMPARE_PY="${p}"
+        break
+    fi
+done
+
+if [[ -z "${COMPARE_PY}" ]]; then
+    echo "ERROR: Could not find Google Benchmark compare.py."
+    echo "Run 'make bench-configure' first to fetch the dependency."
+    exit 1
+fi
+
+if [[ $# -ge 2 ]]; then
+    FILE1="${1}"
+    FILE2="${2}"
+else
+    SORTED=($(ls -t "${RESULTS_DIR}"/*.json 2>/dev/null))
+    if [[ ${#SORTED[@]} -lt 2 ]]; then
+        echo "ERROR: Need at least 2 result files in ${RESULTS_DIR}/."
+        echo "Run 'make bench-run' at least twice, or pass two filenames explicitly."
+        exit 1
+    fi
+    FILE2="${SORTED[0]}"
+    FILE1="${SORTED[1]}"
+    echo "Comparing:"
+    echo "  baseline : ${FILE1}"
+    echo "  candidate: ${FILE2}"
+fi
+
+python3 "${COMPARE_PY}" benchmarks "${FILE1}" "${FILE2}"

--- a/scripts/bench_compare.sh
+++ b/scripts/bench_compare.sh
@@ -39,4 +39,4 @@ else
     echo "  candidate: ${FILE2}"
 fi
 
-python3 "${COMPARE_PY}" benchmarks "${FILE1}" "${FILE2}"
+uv run --with numpy --with scipy "${COMPARE_PY}" benchmarks "${FILE1}" "${FILE2}"

--- a/scripts/bench_compare.sh
+++ b/scripts/bench_compare.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-RESULTS_DIR="benchmark_results"
+RESULTS_DIR="benchmark_results/local"
 COMPARE_PY_SEARCH_PATHS=(
     "_bench/_deps/googlebenchmark-src/tools/compare.py"
     "_debug/_deps/googlebenchmark-src/tools/compare.py"

--- a/scripts/bench_run.sh
+++ b/scripts/bench_run.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 BENCH_BIN="${1:-_bench/benchmarks/probstructs_benchmark}"
-RESULTS_DIR="benchmark_results"
+RESULTS_DIR="benchmark_results/local"
 
 mkdir -p "${RESULTS_DIR}"
 

--- a/scripts/bench_run.sh
+++ b/scripts/bench_run.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BENCH_BIN="${1:-_bench/benchmarks/probstructs_benchmark}"
+RESULTS_DIR="benchmark_results"
+
+mkdir -p "${RESULTS_DIR}"
+
+TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
+OUTPUT_FILE="${RESULTS_DIR}/${TIMESTAMP}.json"
+
+echo "Running benchmarks: ${BENCH_BIN}"
+echo "Output: ${OUTPUT_FILE}"
+
+"${BENCH_BIN}" \
+    --benchmark_out="${OUTPUT_FILE}" \
+    --benchmark_out_format=json \
+    --benchmark_color=true \
+    "${@:2}"
+
+echo ""
+echo "Results saved to: ${OUTPUT_FILE}"


### PR DESCRIPTION
## Summary

- Adds a `benchmarks/` directory with Google Benchmark (v1.9.1 via FetchContent) covering all three data structures (`CountMinSketch`, `ExponentialHistorgram`, `ExponentialCountMinSketch`) with `inc` and `get` benchmarks across small/medium/large parameter sets
- Adds `scripts/bench_run.sh` to run benchmarks and save timestamped JSON results to `benchmark_results/` (committed to the repo for history)
- Adds `scripts/bench_compare.sh` to compare two runs using Google Benchmark's `compare.py`; auto-selects the two most-recent files when called without arguments
- Benchmarks are opt-in (`BUILD_BENCHMARKS=OFF` by default) so normal debug/release builds are unaffected

## Usage

```bash
make bench-build          # configure + compile (downloads gbench via FetchContent)
make bench-run            # run and save results to benchmark_results/<timestamp>.json
make bench-run            # run again after a change
make bench-compare        # compare the two most recent results
```

## Test plan

- [ ] `make bench-build` compiles without errors
- [ ] `make bench-run` produces a JSON file in `benchmark_results/`
- [ ] `make bench-run` a second time, then `make bench-compare` shows a comparison table
- [ ] `make debug-build` and `make release-build` still work (benchmarks off by default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)