### PR TITLE
Fix CI not triggering after master merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,6 @@ jobs:
             echo "Nothing to commit."
           else
             git pull --rebase origin master
-            git commit -m "ci: record benchmark results [skip ci]"
+            git commit -m "ci: record benchmark results [skip actions]"
             git push
           fi


### PR DESCRIPTION
## Summary

- Merging PR #5 did not trigger CI because one of its commits contained `[skip ci]` in its message body (describing how the workflow avoids re-triggering itself). GitHub scans the full commit message body anywhere for that string.
- Switch the bot-generated benchmark result commit from `[skip ci]` to `[skip actions]` — both suppress CI, but using different strings ensures a plain-English description of one won't accidentally activate the other.

## Test plan

- [ ] Merging this PR triggers a CI run on master
- [ ] That run commits a baseline to `benchmark_results/ci/` using `[skip actions]`, which does not trigger another run

🤖 Generated with [Claude Code](https://claude.com/claude-code)