### PR TITLE
Fix benchmark commit: pull before staging changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,11 +107,11 @@ jobs:
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git pull --rebase origin master
           git add benchmark_results/ci/
           if git diff --cached --quiet; then
             echo "Nothing to commit."
           else
-            git pull --rebase origin master
             git commit -m "ci: record benchmark results [skip actions]"
             git push
           fi


### PR DESCRIPTION
## Summary

- `git rebase` refuses to run when the index has staged changes — the previous order (`git add` → `git pull --rebase`) caused the job to fail with `cannot pull with rebase: Your index contains uncommitted changes`
- Fix: pull first while the working tree is clean, then stage and commit the result file

## Test plan

- [ ] Merge triggers CI on master
- [ ] Benchmark job completes and commits the first baseline to `benchmark_results/ci/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)