### PR TITLE
ci: add Dependabot for GitHub Actions and docs dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - "martin-majlis"
+
+  - package-ecosystem: "pip"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - "martin-majlis"


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` with weekly update checks for:
  - **GitHub Actions** — covers `actions/checkout`, `actions/upload-artifact`, `astral-sh/setup-uv`, `nicledomaS/cmake_build_action`
  - **pip (docs)** — covers `breathe` in `docs/requirements.txt`
- All PRs assigned to `martin-majlis`
- Runs weekly (Dependabot defaults to Monday)

## CMake note

CMake FetchContent (`fmtlib@10.2.1`, `googletest@v1.14.0`, `googlebenchmark@v1.9.1`) is not a supported Dependabot ecosystem — those deps require manual updates in `CMakeLists.txt`, `tests/CMakeLists.txt`, and `benchmarks/CMakeLists.txt`.

## Verification

After merging: **Insights → Dependency graph → Dependabot** — both ecosystems should show as enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)