### PR TITLE
ci: fall back to github.token when BENCHMARK_TOKEN is unavailable

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0   # full history so we can read master's result files
-          token: ${{ secrets.BENCHMARK_TOKEN }}
+          token: ${{ secrets.BENCHMARK_TOKEN || github.token }}
 
       - uses: astral-sh/setup-uv@v5
 


### PR DESCRIPTION
## Summary

Dependabot PRs cannot access repository secrets, so `secrets.BENCHMARK_TOKEN` is empty and `actions/checkout` fails immediately with:

```
Input required and not supplied: token
```

**Fix:** `token: ${{ secrets.BENCHMARK_TOKEN || github.token }}`

- **PRs (including Dependabot):** `BENCHMARK_TOKEN` is empty → falls back to `github.token`, which is sufficient for checkout and the read-only `git fetch`/`git ls-tree` in the "Find baseline" step. The "Commit results to master" step is skipped (`if: github.ref == 'refs/heads/master'`), so no push is attempted.
- **Master push:** `BENCHMARK_TOKEN` is present → used for checkout, credentials persisted, push to protected branch works as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)