### PR TITLE
docs: pin requirements, add docs-build target and build instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,18 @@ ctest --test-dir _build --output-on-failure
 
 On Windows, ctest needs `-C Debug` because the VS generator is multi-config.
 
+## Docs
+
+Requires **Doxygen**, **Graphviz**, and the Python packages in `docs/requirements.txt` (`breathe`, `sphinx-rtd-theme`).
+
+```bash
+# macOS: brew install doxygen graphviz && pip install -r docs/requirements.txt
+# Linux: apt-get install doxygen graphviz && pip install -r docs/requirements.txt
+make docs-build   # output: _docs/docs/sphinx/
+```
+
+Docs are also published automatically at https://probstructs.readthedocs.io via ReadTheDocs.
+
 ## Benchmarks
 
 Google Benchmark suite, opt-in (`BUILD_BENCHMARKS=OFF` by default).

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,17 @@ release-test: release-build
 	_release/tests/probstructs_test
 
 
+_docs: docs-configure
+
+docs-configure:
+	$(CMAKE) -S . -DCMAKE_BUILD_TYPE=Release -B _docs
+
+docs-build: _docs
+	$(CMAKE) --build _docs --target Sphinx
+
+
 clean:
-	rm -rf _debug _release _bench
+	rm -rf _debug _release _bench _docs
 
 
 _bench: bench-configure

--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,35 @@ Example
     // 0
 
 
+Building the docs
+-----------------
+
+Prerequisites: **CMake 3.11+**, **Doxygen**, **Graphviz**, and the Python
+packages listed in ``docs/requirements.txt`` (``breathe`` and
+``sphinx-rtd-theme``).
+
+macOS:
+
+.. code-block:: bash
+
+    brew install cmake doxygen graphviz
+    pip install -r docs/requirements.txt
+
+Ubuntu/Debian:
+
+.. code-block:: bash
+
+    sudo apt-get install cmake doxygen graphviz
+    pip install -r docs/requirements.txt
+
+Then build:
+
+.. code-block:: bash
+
+    make docs-build
+
+The generated HTML lands in ``_docs/docs/sphinx/``.
+
 Benchmarks
 ----------
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
-breathe
+breathe==4.36.0
+sphinx-rtd-theme==3.1.0


### PR DESCRIPTION
## Summary

- **Pin `docs/requirements.txt`** — `breathe==4.36.0` and `sphinx-rtd-theme==3.1.0` (theme was missing from the file entirely). Dependabot will now open version-bump PRs for both.
- **New Makefile targets** — `make docs-build` configures and builds Sphinx docs into `_docs/docs/sphinx/`. Follows the same `configure`/`build` pattern as the existing debug/release/bench targets. `make clean` now also removes `_docs`.
- **README.rst** — new "Building the docs" section with prerequisites and commands for macOS and Ubuntu.
- **CLAUDE.md** — brief docs section with the same information.

## Prerequisites (not installed by this PR)

```bash
# macOS
brew install doxygen graphviz
pip install -r docs/requirements.txt

# Ubuntu/Debian
sudo apt-get install doxygen graphviz
pip install -r docs/requirements.txt
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)