### PR TITLE
ci: make benchmark regression check non-blocking; fix token fallback

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0   # full history so we can read master's result files
-          token: ${{ secrets.BENCHMARK_TOKEN }}
+          token: ${{ secrets.BENCHMARK_TOKEN || github.token }}
 
       - uses: astral-sh/setup-uv@v5
 
@@ -59,6 +59,7 @@ jobs:
 
       - name: Check for regressions
         if: steps.baseline.outputs.exists == 'true'
+        continue-on-error: true
         run: |
           uv run scripts/bench_check_regression.py \
             --baseline /tmp/baseline.json \


### PR DESCRIPTION
## Summary

- **`continue-on-error: true`** on the "Check for regressions" step — the regression check still runs and prints its full report (improvements, regressions, geomean) for visibility, but a detected regression no longer fails the workflow or blocks a PR.
- **Always stores on master** — because the regression check step no longer hard-fails, the "Commit results to master" step is no longer skipped when regressions are detected. Results are committed to `benchmark_results/ci/` on every master push.
- **Token fallback** — `secrets.BENCHMARK_TOKEN || github.token` so Dependabot PRs (which cannot access repository secrets) no longer fail at the checkout step. Supersedes PR #18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)