### PR TITLE
docs: add .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,15 @@
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+  apt_packages:
+    - doxygen
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
## Summary

ReadTheDocs now requires an explicit `.readthedocs.yaml` at the repo root — without it builds use deprecated legacy defaults and fail with "missing required files".

The project already has a working Sphinx + Doxygen + Breathe stack; `docs/conf.py` detects `READTHEDOCS=True` and runs `doxygen` + configures Breathe automatically. This file just supplies the environment that code needs:

- `build.apt_packages: [doxygen]` — `conf.py` calls `subprocess.call('doxygen')` on RTD; the binary must be present
- `python.install` → `docs/requirements.txt` — installs `breathe` (and `sphinx-rtd-theme` once PR #19 merges)
- `sphinx.configuration: docs/conf.py` — tells RTD where to find the Sphinx config
- `ubuntu-24.04` + `python: "3.12"` — current LTS + stable Python

No changes to `conf.py`, `Doxyfile.in`, or CMake files.

## Verification

After merging, check https://readthedocs.org/projects/probstructs/builds/ — the build should pass and API reference pages should show the Doxygen-generated class docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)